### PR TITLE
Fix leftover space default values for names.

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -51,7 +51,7 @@ unsigned char nicknames[11] = {
 
 typedef struct TraderPacket {
     // Name must not exceed 10 characters + 1 STOP_BYTE
-    // Any leftover space after must be filled with STOP_BYTE
+    // Any leftover space must be filled with STOP_BYTE
     unsigned char name[11];
     struct SelectedPokemon selected_pokemon;
     struct PartyMember pokemon[6];

--- a/comm.c
+++ b/comm.c
@@ -40,18 +40,18 @@ unsigned char nicknames[11] = {
     pokechar_E, 
     pokechar_W, 
     pokechar_STOP_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
-    pokechar_NULL_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
+    pokechar_STOP_BYTE, 
 };
 
 typedef struct TraderPacket {
     // Name must not exceed 10 characters + 1 STOP_BYTE
-    // Any leftover space after STOP_BYTE must be filled with NULL_BYTE
+    // Any leftover space after must be filled with STOP_BYTE
     unsigned char name[11];
     struct SelectedPokemon selected_pokemon;
     struct PartyMember pokemon[6];


### PR DESCRIPTION
Originally leftover space is filled with 0x50, not 0x00, you can check any original .sav file to confirm it.